### PR TITLE
[Sync] Update project files from source repository (31ecff7)

### DIFF
--- a/.github/CODE_STANDARDS.md
+++ b/.github/CODE_STANDARDS.md
@@ -45,7 +45,6 @@ When in doubt, check the official docs:
 * 📃 [godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc)
 * 🔧 [gofmt](https://golang.org/cmd/gofmt/)
 * 📊 [golangci-lint](https://golangci-lint.run/)
-* 📈 [Go Report Card](https://goreportcard.com/)
 
 <br/>
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,6 @@ We follow [Effective Go](https://golang.org/doc/effective_go.html), plus:
 
 * 📖 [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc)
 * 🧼 [golangci-lint](https://golangci-lint.run/)
-* 🧾 [Go Report Card](https://goreportcard.com/)
 
 Format your code with `gofmt`, lint with `golangci-lint`, and keep your diffs minimal.
 

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.24.1
+MAGE_X_VERSION=v1.25.0
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -70,9 +70,9 @@ MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea
 # ================================================================================================
 
 MAGE_X_GITLEAKS_VERSION=8.30.1
-MAGE_X_GOFUMPT_VERSION=v0.10.0
+MAGE_X_GOFUMPT_VERSION=v0.11.0
 MAGE_X_GOLANGCI_LINT_VERSION=v2.12.2
-MAGE_X_GORELEASER_VERSION=v2.17.0
+MAGE_X_GORELEASER_VERSION=v2.17.1
 MAGE_X_GOVULNCHECK_VERSION=v1.1.4
 MAGE_X_GO_SECONDARY_VERSION=1.24.x
 MAGE_X_GO_VERSION=1.24.x

--- a/.github/env/10-pre-commit.env
+++ b/.github/env/10-pre-commit.env
@@ -53,7 +53,7 @@ GO_PRE_COMMIT_ALL_FILES=true
 # ================================================================================================
 
 GO_PRE_COMMIT_GOLANGCI_LINT_VERSION=v2.12.2
-GO_PRE_COMMIT_FUMPT_VERSION=v0.10.0
+GO_PRE_COMMIT_FUMPT_VERSION=v0.11.0
 GO_PRE_COMMIT_GOIMPORTS_VERSION=latest
 GO_PRE_COMMIT_GITLEAKS_VERSION=v8.30.1
 


### PR DESCRIPTION
## What Changed

* Removed "Go Report Card" references from `.github/CODE_STANDARDS.md` and `.github/CONTRIBUTING.md` documentation
* Updated `MAGE_X_VERSION` from `v1.24.1` to `v1.25.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GOFUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GORELEASER_VERSION` from `v2.17.0` to `v2.17.1` in `.github/env/10-mage-x.env`
* Updated `GO_PRE_COMMIT_FUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-pre-commit.env`

## Why It Was Necessary

* Go Report Card is no longer used as a code quality tool, so references were removed from developer documentation
* Mage-X and its dependencies needed to be upgraded to their latest versions for bug fixes and improvements
* Keeping gofumpt versions synchronized across mage-x and pre-commit environments ensures consistent code formatting

## Testing Performed

* Verified all version numbers in configuration files are syntactically correct
* Confirmed documentation changes maintain proper markdown formatting
* Validated that removed Go Report Card references don't break documentation links or structure

## Impact / Risk

* **Low Risk** - Documentation and version updates only, no code changes
* **No Breaking Changes** - Tool version updates are backward compatible
* **Developer Experience** - Developers will use updated tool versions; documentation is clearer without unused tools

<!-- go-broadcast-metadata
group:
  id: mrz-sdks
  name: mrz-sdks
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 31ecff74272ac87c2e6ed4bfe911cea832a98edb
  target_repo: mrz1836/go-parameters
  sync_commit: ea9f27474a20c892fdfa538edcf0f9f2a6e0aa48
  sync_time: 2026-07-28T12:31:07-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 289
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 778
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 271
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 2
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 577
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 492
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1425
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1419
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 883
performance:
  total_files: 103
-->
